### PR TITLE
Get rid of epoch and parameterize variables

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
+# Exports .env variables to local environment
+export "$(grep -E 'PINOT_APP_NAME' docker/.env)"
+export "$(grep -E 'IMPORT_SCRIPT' docker/.env)"
+
 # Imports NOAA storm event data into Apache Pinot
-docker exec -ti pinot_app_noaa bash -c "sh ./import/import-storm-events.sh"
+docker exec -ti "$PINOT_APP_NAME" bash -c "sh $IMPORT_SCRIPT"
 
 # Initializes the Superset application and imports datasources and dashboards
-docker exec -ti -u root superset_app_noaa bash -c "sh ./docker-init.sh"
+docker exec -ti -u root "$SUPERSET_APP_NAME" bash -c "sh ./docker-init.sh"
 
-# Open the browser for Pinot and Superset
-open http://localhost:9000
+# Open the browser for Pinot query console and Superset dashboard page
+open http://localhost:9000/#/query
 open http://localhost:8088
 
 echo "Success! Login to Superset using the credentials admin/admin"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
   superset:
     env_file: docker/.env
     image: kbastani2/noaa-pinot-superset-app
-    container_name: superset_app_noaa
+    container_name: ${SUPERSET_APP_NAME}
     command: ["flask", "run", "-p", "8088", "--with-threads", "--reload", "--debugger", "--host=0.0.0.0"]
     restart: unless-stopped
     ports:
@@ -70,8 +70,10 @@ services:
       - PinotNetwork
 
   pinot:
-    image: apachepinot/pinot:0.5.0-SNAPSHOT-c223dfcfb-20200821
-    container_name: pinot_app_noaa
+    env_file:
+      - docker/.env
+    image: apachepinot/pinot:latest
+    container_name: ${PINOT_APP_NAME}
     command: ["QuickStart", "-type", "BATCH"]
     restart: unless-stopped
     ports:
@@ -84,7 +86,6 @@ services:
 
 networks:
   PinotNetwork:
-    external:
       name: PinotNetwork
 
 volumes:

--- a/docker/.env
+++ b/docker/.env
@@ -43,3 +43,19 @@ REDIS_PORT=6379
 FLASK_ENV=development
 SUPERSET_ENV=development
 SUPERSET_LOAD_EXAMPLES=yes
+
+# Pinot app
+PINOT_APP_NAME=pinot_app_noaa
+TABLE_CONFIG_PATH=/opt/pinot/import/storm-events-table-config.json
+TABLE_SCHEMA_PATH=/opt/pinot/import/storm-events-schema.json
+JOB_SPEC_PATH=/opt/pinot/import/storm-events-job-spec.yml
+IMPORT_SCRIPT=/opt/pinot/import/import-storm-events.sh
+RAW_DATA_DIR=/opt/pinot/import/rawdata
+
+# Superset
+SUPERSET_APP_NAME=superset_app_noaa
+SUPERSET_USERNAME=admin
+SUPERSET_FIRSTNAME=Superset
+SUPERSET_LASTNAME=Admin
+SUPERSET_EMAIL=admin@superset.com
+SUPERSET_PASSWORD=admin

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -36,11 +36,11 @@ EOF
 # Create an admin user
 echo_step "1" "Starting" "Setting up admin user ( admin / admin )"
 superset fab create-admin \
-              --username admin \
-              --firstname Superset \
-              --lastname Admin \
-              --email admin@superset.com \
-              --password admin
+              --username "$SUPERSET_USERNAME" \
+              --firstname "$SUPERSET_FIRSTNAME" \
+              --lastname "$SUPERSET_LASTNAME" \
+              --email "$SUPERSET_EMAIL" \
+              --password "$SUPERSET_PASSWORD"
 echo_step "1" "Complete" "Setting up admin user"
 
 # Initialize the database

--- a/import/import-storm-events.sh
+++ b/import/import-storm-events.sh
@@ -1,34 +1,30 @@
 #!/bin/bash
 
-echo "Adding 'stormEvents' table to Pinot..."
-
-# Adds a new Pinot table for the NOAA storm event data
-/opt/pinot/bin/pinot-admin.sh AddTable -tableConfigFile /opt/pinot/import/storm-events-table-config.json -schemaFile /opt/pinot/import/storm-events-schema.json -exec
-
+# Download climate data
 echo "Downloading CSV files from NOAA server..."
-
+mkdir "$RAW_DATA_DIR"
 wget -m ftp://ftp.ncdc.noaa.gov:21/pub/data/swdi/stormevents/csvfiles/StormEvents_details-ftp_v1.0_*.csv.gz
 
-FILES=./ftp.ncdc.noaa.gov/pub/data/swdi/stormevents/csvfiles/StormEvents_details-ftp_v1.0_*.csv
-ZIPPED_FILES=./ftp.ncdc.noaa.gov/pub/data/swdi/stormevents/csvfiles/StormEvents_details-ftp_v1.0_*.csv.gz
+# Unzip files into raw data dir
+echo "Unzipping files into $RAW_DATA_DIR"
+ZIPPED_FILES="./ftp.ncdc.noaa.gov/pub/data/swdi/stormevents/csvfiles/StormEvents_details-ftp_v1.0_*.csv.gz"
 for f in $ZIPPED_FILES
 do
-  echo "Unzipping $f file..."
-  # take action on each file. $f store current file name
-  gunzip $f
+  STEM=$(basename "${f}" .gz)
+  gunzip -c "${f}" > "$RAW_DATA_DIR/${STEM}"
 done
 
-# Move downloaded CSV files to subdirectory
-mkdir /opt/pinot/import/rawdata
-mv $FILES /opt/pinot/import/rawdata
-
-# Clean up
+# Clean up old files
 echo "NOAA storm event data downloaded!"
-
 echo "Cleaning up..."
-rm -rf ./ftp.ncdc.noaa.gov
+rm -rfv ./ftp.ncdc.noaa.gov
 
+# Create table
+bin/pinot-admin.sh AddTable \
+  -tableConfigFile "$TABLE_CONFIG_PATH" \
+  -schemaFile "$TABLE_SCHEMA_PATH" -exec
+
+# Ingest data
 echo "Launching Pinot data ingestion job from raw storm event files..."
-
-# Launch batch ingestion job from raw CSV files into Pinot
-/opt/pinot/bin/pinot-admin.sh LaunchDataIngestionJob -jobSpecFile /opt/pinot/import/storm-events-job-spec.yml
+bin/pinot-admin.sh LaunchDataIngestionJob \
+  -jobSpecFile "$JOB_SPEC_PATH"

--- a/import/storm-events-schema.json
+++ b/import/storm-events-schema.json
@@ -208,12 +208,6 @@
         "dataType":"LONG",
         "format":"1:SECONDS:EPOCH",
         "granularity":"1:MINUTES"
-      },
-      {
-         "name":"BEGIN_DATE_TIME",
-         "dataType":"STRING",
-         "format":"1:SECONDS:SIMPLE_DATE_FORMAT:dd-MMM-yy HH:mm:ss",
-         "granularity":"1:MINUTES"
       }
    ]
 }

--- a/import/storm-events-table-config.json
+++ b/import/storm-events-table-config.json
@@ -1,31 +1,25 @@
 {
-   "tableName":"stormEvents",
-   "segmentsConfig":{
-      "segmentAssignmentStrategy":"BalanceNumSegmentAssignmentStrategy",
-      "segmentPushType":"APPEND",
-      "schemaName":"stormEvents",
-      "replication":1
-   },
-   "tableIndexConfig":{
-      "invertedIndexColumns":[
-
-      ],
-      "loadMode":"MMAP"
-   },
-   "tenants":{
-      "broker":"DefaultTenant",
-      "server":"DefaultTenant"
-   },
-   "tableType":"OFFLINE",
-   "metadata":{
-      "customConfigs": {
-
-      }
-   },
-   "ingestionConfig": {
-     "transformConfigs": [{
-       "columnName": "EPOCH_TIMESTAMP",
-       "transformFunction": "fromDateTime(BEGIN_DATE_TIME, 'dd-MMM-yy HH:mm:ss')"
-    }]
+  "tableName": "stormEvents",
+  "segmentsConfig": {
+    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
+    "segmentPushType": "APPEND",
+    "schemaName": "stormEvents",
+    "replication": 1
+  },
+  "tableIndexConfig": {
+    "invertedIndexColumns": [
+    ],
+    "loadMode": "MMAP"
+  },
+  "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
+  },
+  "tableType": "OFFLINE",
+  "metadata": {
+    "customConfigs": {
+    }
+  },
+  "ingestionConfig": {
   }
 }


### PR DESCRIPTION
* Gets rid of the epoch timestamp, which causes issues with pre-epoch datetimes
* Uses the latest version of Pinot
* Parameterizes a lot of variables to help centralize things in `.env`